### PR TITLE
refactor wizard feature

### DIFF
--- a/bdd_tests/features/wizard.feature
+++ b/bdd_tests/features/wizard.feature
@@ -1,37 +1,34 @@
 Feature: Wizard
   Scenario: I start out with Houghton
-    When I access the url "/"
+    Given I am on the survey
     Then I see the header "Houghton Questions"
 
-  Scenario: There is a next button
-    When I access the url "/"
+  Scenario: There is a next butto
+    Given I am on the survey
     Then I see a "Next >" button
 
   Scenario: Clicking Next moves me forward
-    When I access the url "/"
-    When I click the "Next >" button
+    Given I am on the survey
+    When I advance through the wizard
     Then I see the header "Activites-specific Balance Confidence (ABC) Scale"
-    When I click the "Next >" button
+    When I advance through the wizard
     Then I see the header "Demonstrate your abilities"
-    When I click the "Next >" button
+    When I advance through the wizard
     Then I see the header "Demonstrate your abilities"
     Then I see the text "Look behind (both) shoulders"
-    When I click the "Next >" button
+    When I advance through the wizard
     Then I see the text "View Results"
 
   Scenario: I can go back
-    When I access the url "/"
-    When I click the "Next >" button
-    When I click the "Next >" button
-    When I click the "Next >" button
-    When I click the "Next >" button
+    Given I am on the survey
+      and I have advanced to the end
     Then I see the text "View Results"
-    When I click the "< Previous" button
+    When I reverse through the wizard
     Then I see the header "Demonstrate your abilities"
     Then I see the text "Look behind (both) shoulders"
-    When I click the "< Previous" button
+    When I reverse through the wizard
     Then I see the header "Demonstrate your abilities"
-    When I click the "< Previous" button
+    When I reverse through the wizard
     Then I see the header "Activites-specific Balance Confidence (ABC) Scale"
-    When I click the "< Previous" button
+    When I reverse through the wizard
     Then I see the header "Houghton Questions"

--- a/bdd_tests/steps/wizard.py
+++ b/bdd_tests/steps/wizard.py
@@ -1,6 +1,11 @@
 from behave import when, then
 
 
+@given(u'I am on the survey')
+def impl(context):
+    context.browser.visit(context.browser_url("/"))
+
+
 @then(u'I see the header "{text}"')
 def i_see_the_header(context, text):
     assert context.browser.is_text_present(text, wait_time=2)
@@ -25,3 +30,22 @@ def i_click_the_button(context, text):
         if button.text == text and button.visible:
             button.click()
             return
+
+
+@given(u'I have advanced to the end')
+def impl(context):
+    i_click_the_button(context, "Next >")
+    i_click_the_button(context, "Next >")
+    i_click_the_button(context, "Next >")
+    i_click_the_button(context, "Next >")
+    i_click_the_button(context, "Next >")
+
+
+@when(u'I advance through the wizard')
+def impl(context):
+    i_click_the_button(context, "Next >")
+
+
+@when(u'I reverse through the wizard')
+def impl(context):
+    i_click_the_button(context, "< Previous")

--- a/bdd_tests/steps/wizard.py
+++ b/bdd_tests/steps/wizard.py
@@ -1,4 +1,4 @@
-from behave import when, then
+from behave import when, then, given
 
 
 @given(u'I am on the survey')
@@ -33,7 +33,7 @@ def i_click_the_button(context, text):
 
 
 @given(u'I have advanced to the end')
-def impl(context):
+def i_have_advanced_to_the_end(context):
     i_click_the_button(context, "Next >")
     i_click_the_button(context, "Next >")
     i_click_the_button(context, "Next >")
@@ -42,10 +42,10 @@ def impl(context):
 
 
 @when(u'I advance through the wizard')
-def impl(context):
+def i_advance_through_the_wizard(context):
     i_click_the_button(context, "Next >")
 
 
 @when(u'I reverse through the wizard')
-def impl(context):
+def i_reverse_through_the_wizard(context):
     i_click_the_button(context, "< Previous")


### PR DESCRIPTION
trying to get the language of the test a little more high level.
BDD best practice is to stick as close as possible to client/domain language
and avoid technical details as much as possible.

These changes make the test more robust in the face of changes to
site structure and button labels (the step definitions have to
change, but the feature file itself should be able to remain
unchanged even if we split the wizard across multiple pages,
renamed buttons, etc.)