### PR TITLE
Behave test for running through the whole survey, filling in values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ flake8: ./ve/bin/python
 behave: ./ve/bin/python check
 	$(MANAGE) test bdd_tests --behave_browser firefox --testrunner=django_behave.runner.DjangoBehaveTestSuiteRunner
 
+behave-wip: ./ve/bin/python check
+	$(MANAGE) test bdd_tests --behave_tags @wip --behave_browser firefox --testrunner=django_behave.runner.DjangoBehaveTestSuiteRunner
+
 runserver: ./ve/bin/python check
 	$(MANAGE) runserver
 

--- a/bdd_tests/features/runthrough.feature
+++ b/bdd_tests/features/runthrough.feature
@@ -1,0 +1,16 @@
+Feature: Run through the survey
+
+User should be able to enter responses to all
+the questions and get their score/results at the end.
+
+  Scenario: Low Score
+    Given I am on the survey
+      and I enter the minimum on all questions
+    When I submit
+    Then I am shown a failing result
+
+  Scenario: High Score
+    Given I am on the survey
+      and I enter the maximum on all questions
+    When I submit
+    Then I am shown a passing result

--- a/bdd_tests/steps/runthrough.py
+++ b/bdd_tests/steps/runthrough.py
@@ -1,0 +1,81 @@
+from behave import when, then, given
+import time
+
+
+@given(u'I am on the survey')
+def i_am_on_the_survey(context):
+    context.browser.visit(context.browser_url("/"))
+
+
+def advance(context):
+    for button in context.browser.find_by_css('ul.pager a'):
+        if button.text == "Next >" and button.visible:
+            button.click()
+            return
+
+
+@given(u'I enter the minimum on all questions')
+def i_enter_the_minimum_on_all_questions(context):
+    context.browser.choose('q1', '1')
+    context.browser.choose('q2', '1')
+    context.browser.choose('q3', '1')
+    context.browser.choose('q4', '1')
+    context.browser.choose('q5', '1')
+    context.browser.choose('q6', '1')
+    advance(context)
+    # ABCs default to 0
+    advance(context)
+    context.browser.choose('q23', '1')
+    advance(context)
+    context.browser.choose('q24', '1')
+    advance(context)
+    # ready to submit
+
+
+@given(u'I enter the maximum on all questions')
+def i_enter_the_maximum_on_all_questions(context):
+    context.browser.choose('q1', '4')
+    context.browser.choose('q2', '4')
+    context.browser.choose('q3', '4')
+    context.browser.choose('q4', '2')
+    context.browser.choose('q5', '2')
+    context.browser.choose('q6', '2')
+    advance(context)
+    # jquery UI sliders are a bit hard to automate
+    # could probably do it with drag and drop
+    # but this is simpler and seems reliable
+    for i in range(1, 17):
+        context.browser.execute_script(
+            "$('#abc-%d-slider').slider('value', 10)" % i)
+        context.browser.execute_script(
+            "$('#abc-%d').val(10)" % i)
+    time.sleep(5)
+    advance(context)
+    context.browser.choose('q23', '2')
+    advance(context)
+    context.browser.choose('q24', '2')
+    advance(context)
+    # ready to submit
+
+
+@when(u'I submit')
+def i_submit(context):
+    context.browser.find_by_id('submit-button').first.click()
+
+
+@then(u'I am shown a passing result')
+def i_am_shown_a_passing_result(context):
+    b = context.browser
+    assert "PASS" in b.find_by_id('houghton-result').first.text
+    assert "PASS" in b.find_by_id('abc-result').first.text
+    assert "PASS" in b.find_by_id('pickup-result').first.text
+    assert "PASS" in b.find_by_id('look-behind-result').first.text
+
+
+@then(u'I am shown a failing result')
+def i_ams_shown_a_failing_result(context):
+    b = context.browser
+    assert "FAIL" in b.find_by_id('houghton-result').first.text
+    assert "FAIL" in b.find_by_id('abc-result').first.text
+    assert "FAIL" in b.find_by_id('pickup-result').first.text
+    assert "FAIL" in b.find_by_id('look-behind-result').first.text

--- a/pump/templates/main/response_detail.html
+++ b/pump/templates/main/response_detail.html
@@ -6,7 +6,7 @@
 
 <dl>
 	<dt>Houghton</dt>
-	<dd>
+	<dd id="houghton-result">
 		{% if results.houghton.pass_fail %}
 		PASS
 		{% else %}
@@ -15,7 +15,7 @@
 		({{results.houghton.score}}/18)
 	</dd>
 	<dt>ABC</dt>
-	<dd>
+	<dd id="abc-result">
 		{% if results.abc.pass_fail %}
 		PASS
 		{% else %}
@@ -24,7 +24,7 @@
 		({{results.abc.score}}/160)
 	</dd>
 	<dt>Pick Up</dt>
-	<dd>
+	<dd id="pickup-result">
 		{% if results.pick_up.pass_fail %}
 		PASS
 		{% else %}
@@ -32,7 +32,7 @@
 		{% endif %}
 	</dd>
 	<dt>Look Behind</dt>
-	<dd>
+	<dd id="look-behind-result">
 		{% if results.look_behind.pass_fail %}
 		PASS
 		{% else %}


### PR DESCRIPTION
Also added the `behave-wip` make target. This is handy as more and more tests are added. If you annotate the scenario(s) you are working on with `@wip`, you can then run `make behave-wip` and it will skip all the other scenarios so you can get much faster feedback. When you're done, remove the `@wip` annotation and run the regular `make behave` to check that nothing else was broken.