### PR TITLE
move common step definitions out.

### DIFF
--- a/bdd_tests/steps/common.py
+++ b/bdd_tests/steps/common.py
@@ -1,0 +1,6 @@
+from behave import given
+
+
+@given(u'I am on the survey')
+def i_am_on_the_survey(context):
+    context.browser.visit(context.browser_url("/"))

--- a/bdd_tests/steps/runthrough.py
+++ b/bdd_tests/steps/runthrough.py
@@ -2,11 +2,6 @@ from behave import when, then, given
 import time
 
 
-@given(u'I am on the survey')
-def i_am_on_the_survey(context):
-    context.browser.visit(context.browser_url("/"))
-
-
 def advance(context):
     for button in context.browser.find_by_css('ul.pager a'):
         if button.text == "Next >" and button.visible:

--- a/bdd_tests/steps/wizard.py
+++ b/bdd_tests/steps/wizard.py
@@ -1,11 +1,6 @@
 from behave import when, then, given
 
 
-@given(u'I am on the survey')
-def impl(context):
-    context.browser.visit(context.browser_url("/"))
-
-
 @then(u'I see the header "{text}"')
 def i_see_the_header(context, text):
     assert context.browser.is_text_present(text, wait_time=2)


### PR DESCRIPTION
it seems like, depending on the order that things get imported
behave sometimes complains about duplicated step definitions
so i've pulled the common one(s) out to a seperate file for
now.