### PR TITLE
don't allow Next button to work if it is disabled

### DIFF
--- a/media/js/src/wizard.js
+++ b/media/js/src/wizard.js
@@ -28,7 +28,7 @@
 
         var registerRadioListener = function(section) {
             var radios = $(self.sections[section])
-								.find('input[type="radio"]');
+                .find('input[type="radio"]');
             radios.change(function(e) {
                 if (allRadioButtonsSelected(radios)) {
                     $(self.sections[section])
@@ -92,14 +92,16 @@
                 var a = $('<a>Next &gt;</a>')
                     .attr({href: '#', class: 'btn next-button',
                         id: 'next-button-' + index});
-                if (index !== 1) {
+                if (index !== 2) {
                     // all sections except ABC need questions answered
                     // before you can advance
                     a.attr({disabled: 'disabled'});
                 }
                 var nb = $('<li></li>').append(a);
-
                 nb.click(function(event) {
+                    if (a.attr('disabled') === 'disabled') {
+                        return false;
+                    }
                     w.showNextSection();
                     return false;
                 });


### PR DESCRIPTION
I think something changed in bootstrap at some point without us
noticing. The 'Next' button is disabled on most sections until all the
questions have been answered. That still works as far as the bootstrap
CSS. The button clearly appears disabled. However, it still triggers the
click event, so the user can still move forward without answering the
questions.

So, explicitly check the disabled state of the button when it's clicked
and don't advance if it is disabled.

(also change the section id of the one section that can always advance).