### PR TITLE
Remove enum34

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ pep8==1.7.1
 pyflakes==1.6.0
 mccabe==0.6.1
 pycodestyle==2.3.1
-enum34==1.1.6
 configparser==3.5.0
 flake8==3.5.0
 tornado==4.5.3


### PR DESCRIPTION
This isn't necessary in python 3 - i've added this to our wiki page.