### PR TITLE
Remove uuid from requirements (use uuid from Python3 lib)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Django==1.11.10 # pyup: <2.0
 Markdown==2.6.11
-uuid==1.30
 psycopg2==2.7.4
 versiontools==1.9.1
 statsd==3.2.2


### PR DESCRIPTION
Restarting Gunicorn would throw a syntax error in uuid. It seems that
Pump is using an old uuid module for Python 2. This commit removes it
from requirements.txt so that the site defaults to the uuid in Python
3's standard lib.